### PR TITLE
Support setting the attachment name in Trello

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
     required: true
   github-url:
     required: true
+  attachment-name:
+    description: 'The display text to use in Trello. If not supplied, Trello will default to using the URL.'
+    required: false
   trello-api-token:
     required: true
   trello-api-key:

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const trelloCardUrlRe = 'https://trello.com/c/(\\w{8})'
 try {
   const commentBody = core.getInput('comment-body')
   const githubUrl = core.getInput('github-url')
+  const attachmentName = core.getInput('attachment-name')
   const trelloApiToken = core.getInput('trello-api-token')
   if (trelloApiToken === '') {
     core.warning('trello-api-token is empty!')
@@ -17,10 +18,15 @@ try {
   }
   core.setSecret(trelloApiKey)
 
-  function trelloApiUrl(endpoint) {
+  function trelloApiUrl(endpoint, urlParams) {
     const url = new URL(`https://api.trello.com/1${endpoint}`)
     url.searchParams.set('key', trelloApiKey)
     url.searchParams.set('token', trelloApiToken)
+
+    for(const [key, value] in Object.entries(urlParams || {})) {
+      url.searchParams.set(key, value)
+    }
+
     return url.toString()
   }
 
@@ -31,14 +37,26 @@ try {
     const trelloCardId = match[1]
 
     const { result: trelloCardAttachments } = await http.getJson(
-      trelloApiUrl(`/cards/${trelloCardId}/attachments?fields=url`)
+      trelloApiUrl(`/cards/${trelloCardId}/attachments`, {"fields": "url"})
     )
     if (trelloCardAttachments.find((attachment) => attachment.url.startsWith(githubUrl))) {
       // nothing to do, break out
       core.info(`Trello card ${trelloCardUrl} already has GitHub link ${githubUrl} attached`)
     } else {
+      let params = {
+        url: githubUrl
+      }
+
+      if (attachmentName != null) {
+        // Name parameter can be maximum 256 characters, so trim it to that
+        if (attachmentName.len() > 256) {
+          core.info("'attachment-name' property can be a maximum of 256 characters. Truncating.")
+        }
+        params.name = attachmentName.substring(0, 257)
+      }
+
       await http.postJson(
-        trelloApiUrl(`/cards/${trelloCardId}/attachments?url=${githubUrl}`)
+        trelloApiUrl(`/cards/${trelloCardId}/attachments`, params)
       )
       core.info(`Successfully attached GitHub link ${githubUrl} to Trello card ${trelloCardUrl}`)
     }


### PR DESCRIPTION
When adding a PR link to Trello automatically, it'd be nice to be able to show the PR title instead of the link URL by default.

Does this by setting the [`name` property on POST request to create an attachment](https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-attachments-post) if the input has been set.