### PR TITLE
Add logic to handle mirror cards

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,18 @@ try {
     core.debug(`Found Trello card link ${match[0]}`)
 
     const http = new HttpClient('trello-poster-action')
-    const trelloCardUrl = match[0]
-    const trelloCardId = match[1]
+    let trelloCardUrl = match[0]
+    let trelloCardId = match[1]
+
+    // handle mirror cards
+    const { result: trelloCard } = await http.getJson(
+      trelloApiUrl(`/cards/${trelloCardId}`)
+    )
+    if (trelloCard.cardRole == "mirror") {
+      core.debug(`Trello card is a mirror card for ${trelloCard.name}, updating that card instead`)
+      trelloCardUrl = trelloCard.name
+      trelloCardId = trelloCard.mirrorSourceId
+    }
 
     const { result: trelloCardAttachments } = await http.getJson(
       trelloApiUrl(`/cards/${trelloCardId}/attachments`, {"fields": "url"})


### PR DESCRIPTION
Trello card: https://trello.com/c/a3hSuVK1/

Trello has added functionality for mirror cards [[1]], which allow cards
to be on two boards at once. The way this appears to work from the point
of view of the REST API is that a card can have the `role` `mirror`, and
then the `name` of the card points to the original.

Unfortunately it seems that adding an attachment to a mirror card via the
REST API changes the role of the card from `mirror`, breaking the link,
and making the card useless.

This commit fixes the behaviour of the Trello poster so that it checks
whether a card is a mirror card, and updates the card being mirrored if
necessary.

[1]: https://support.atlassian.com/trello/docs/mirroring-cards/