### PR TITLE
Update workflows to test the code in a PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,14 @@
-name: Trello Poster
+name: Test
 on:
   pull_request:
-    types: [created, edited]
+    types: [created, edited, synchronize]
 jobs:
   trello-poster:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfdebrux/trello-poster-action@main
+      - uses: actions/checkout@v4
+      - name: lfdebrux/trello-poster-action@HEAD
+        uses: ./
         with:
           comment-body: ${{ github.event.pull_request.body }}
           github-url: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Currently we have a GitHub Actions workflow that runs the action in the
main branch of this repository for all PRs.

This makes it hard to test change to the action in a PR; either the code
has to be merged first, or the workflow configuration has to be
temporarily changed.

This PR change the workflow to always use the code in the branch for the
PR, so that GitHub Actions will test the changes in the PR more easily.

This is all subject to the security settings for GitHub Actions in this
repo, of course.