### PR TITLE
Bump action runtime from node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
   trello-api-key:
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Using Node16 for actions was deprecated in Spring 2024 [[1]]. Use
the latest available version, Node20 [[2]], instead.

[1]: https://github.blog/changelog/2024-03-06-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
[2]: https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsusing-for-javascript-actions